### PR TITLE
fix(sessionprojector): fix broken scale factor / screen size calculation

### DIFF
--- a/sessionprojector/sessionprojector.xcodeproj/project.pbxproj
+++ b/sessionprojector/sessionprojector.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1BA417EB6724EAD6DCAECF4D /* ScreenLockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA41DE4C1D66522E666A922 /* ScreenLockObserver.swift */; };
 		1BA41CDD3F7820CE5BB5350F /* EventInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA41428CC8179B6149885E2 /* EventInjector.swift */; };
 		1BA41D7932B31577C0D74C45 /* PIDLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA410E8B356C34D306ACAB5 /* PIDLock.swift */; };
+		1BA41DA029C6999341AD2D67 /* CGRect+scale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA4184768E7A11900FB18A7 /* CGRect+scale.swift */; };
 		1BA41EC991D112A154A3A02B /* ProjectionServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA4114256A6041A9024076D /* ProjectionServer.swift */; };
 		85721156283B607000C36D5F /* UlalacaCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85721155283B607000C36D5F /* UlalacaCore.framework */; };
 		85721157283B607000C36D5F /* UlalacaCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 85721155283B607000C36D5F /* UlalacaCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -58,6 +59,7 @@
 		1BA4114256A6041A9024076D /* ProjectionServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectionServer.swift; sourceTree = "<group>"; };
 		1BA41428CC8179B6149885E2 /* EventInjector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventInjector.swift; sourceTree = "<group>"; };
 		1BA414A8380430551765FFBE /* PowerAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PowerAssertion.swift; sourceTree = "<group>"; };
+		1BA4184768E7A11900FB18A7 /* CGRect+scale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGRect+scale.swift"; sourceTree = "<group>"; };
 		1BA4185C06456C7CA943CEBD /* ScreenRecorderErrorDialog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenRecorderErrorDialog.swift; sourceTree = "<group>"; };
 		1BA418EC7026B16C63E68A81 /* SessionManagerClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionManagerClient.swift; sourceTree = "<group>"; };
 		1BA41BC19AD35B7C57EBB6F5 /* PIDLockErrorDialog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PIDLockErrorDialog.swift; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 				1BA416252F6CD6425DC1DC00 /* utils */,
 				1BA41A5115E0474F0EC08982 /* projection */,
 				1BA41B84BA857FB9E439C872 /* ipc */,
+				1BA4184768E7A11900FB18A7 /* CGRect+scale.swift */,
 			);
 			path = sessionprojector;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 				1BA41EC991D112A154A3A02B /* ProjectionServer.swift in Sources */,
 				1BA4105F05F0013D2B32375C /* ScreenRecorderErrorDialog.swift in Sources */,
 				1BA4102AF9986FB7E5B87E5D /* PIDLockErrorDialog.swift in Sources */,
+				1BA41DA029C6999341AD2D67 /* CGRect+scale.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sessionprojector/sessionprojector/CGRect+scale.swift
+++ b/sessionprojector/sessionprojector/CGRect+scale.swift
@@ -1,0 +1,20 @@
+//
+// Created by Gyuhwan Park on 2023/06/28.
+//
+
+import Foundation
+
+extension CGRect {
+    func scale(sx: CGFloat, sy: CGFloat) -> CGRect {
+        return CGRect(
+            x: origin.x * sx,
+            y: origin.y * sy,
+            width: size.width * sx,
+            height: size.height * sy
+        )
+    }
+
+    func scale(by scaleFactor: CGFloat) -> CGRect {
+        return scale(sx: scaleFactor, sy: scaleFactor)
+    }
+}

--- a/sessionprojector/sessionprojector/ipc/ProjectionSession.swift
+++ b/sessionprojector/sessionprojector/ipc/ProjectionSession.swift
@@ -127,10 +127,16 @@ class ProjectionSession: Identifiable {
                 eventInjector?.post(keyEvent: try socket.readCStruct(ULIPCKeyboardEvent.self))
                 break
             case TYPE_EVENT_MOUSE_MOVE:
+                // viewport      -> frameSize      -> screenResolution (actual)
+                // (1600x900@1x) -> (1920x1080@1x) -> (1920x1080@2x) (3840x2160)
+
+                let sx = screenResolution.width * scaleFactor / CGFloat(mainViewport.width)
+                let sy = screenResolution.height * scaleFactor / CGFloat(mainViewport.height)
+
                 eventInjector?.post(
                     mouseMoveEvent: try socket.readCStruct(ULIPCMouseMoveEvent.self),
-                    scaleX: Double(screenResolution.width) / Double(mainViewport!.width),
-                    scaleY: Double(screenResolution.height) / Double(mainViewport!.height)
+                    scaleX: sx,
+                    scaleY: sy
                 )
                 break
             case TYPE_EVENT_MOUSE_BUTTON:

--- a/sessionprojector/sessionprojector/ipc/ProjectionSession.swift
+++ b/sessionprojector/sessionprojector/ipc/ProjectionSession.swift
@@ -88,7 +88,8 @@ class ProjectionSession: Identifiable {
     private(set) public var suppressOutput: Bool = true
 
     private(set) public var screenResolution: CGSize = CGSize(width: 0, height: 0)
-    private(set) public var mainViewport: ViewportInfo?
+    private(set) public var scaleFactor: CGFloat = 1.0
+    private(set) public var mainViewport: ViewportInfo = ViewportInfo(width: 640, height: 480)
 
     init(_ socket: MMUnixSocketConnection) {
         self.id = UUID()
@@ -230,13 +231,10 @@ extension ProjectionSession: ScreenUpdateSubscriber {
 
     func screenUpdated(where rect: CGRect) {
         self.serialQueue.sync {
-            let sx = mainViewport?.scaleX(Int(screenResolution.width)) ?? 1.0
-            let sy = mainViewport?.scaleY(Int(screenResolution.height)) ?? 1.0
-
             self.writeMessage(
                     ULIPCScreenUpdateNotify(
                     type: SCREEN_UPDATE_NOTIFY_TYPE_PARTIAL,
-                    rect: rect.toULIPCRect().scale(x: sx, y: sy)
+                    rect: rect.toULIPCRect()
                 ),
                 type: TYPE_SCREEN_UPDATE_NOTIFY
             )
@@ -250,13 +248,6 @@ extension ProjectionSession: ScreenUpdateSubscriber {
             let pointer = CFDataGetBytePtr(rawData)!
             let length = CFDataGetLength(rawData)
 
-            guard let mainViewport = self.mainViewport else {
-                return
-            }
-
-            let sx = mainViewport.scaleX(Int(screenResolution.width)) ?? 1.0
-            let sy = mainViewport.scaleY(Int(screenResolution.height)) ?? 1.0
-
             let message = ULIPCScreenUpdateCommit(
                 screenRect: ULIPCRect(x: 0, y: 0, width: Int16(mainViewport.width), height: Int16(mainViewport.height)),
                 bitmapLength: UInt64(length)
@@ -267,7 +258,7 @@ extension ProjectionSession: ScreenUpdateSubscriber {
         }
     }
 
-    func screenResolutionChanged(to resolution: CGSize) {
+    func screenResolutionChanged(to resolution: CGSize, scaleFactor: Double) {
         self.screenResolution = resolution
     }
 

--- a/sessionprojector/sessionprojector/recorder/ScreenRecorder.swift
+++ b/sessionprojector/sessionprojector/recorder/ScreenRecorder.swift
@@ -76,13 +76,33 @@ protocol ScreenUpdateSubscriber {
         get
     }
 
-    var mainViewport: ViewportInfo? {
+    var mainViewport: ViewportInfo {
         get
     }
 
+    /**
+     Called when the area of screen marked as dirty.
+     - Parameter rect: dirty area
+     - Note: implementation of ScreenRecorder should pass `rect` scaled to the main viewport.
+     */
     func screenUpdated(where rect: CGRect)
+
+    /**
+     Called when screen capture is ready.
+     - Parameters:
+       - image: content of screen
+       - rect: area of screen captured
+     - Note: implementation of ScreenRecorder should pass `image` / `rect` scaled to the main viewport.
+     */
     func screenReady(image: CGImage, rect: CGRect)
-    func screenResolutionChanged(to resolution: CGSize)
+
+    /**
+     Called when screen resolution is changed.
+     - Parameters:
+       - resolution: new screen resolution
+       - scaleFactor: scale factor (e.g. 2.0 for Retina display)
+     */
+    func screenResolutionChanged(to resolution: CGSize, scaleFactor: Double)
 }
 
 protocol ScreenRecorderDelegate {


### PR DESCRIPTION
# DESCRIPTION
- This PR resolves #13.
  - fixed broken scale factor calculation when posting mouse move events.
  - fixed broken scale factor / screen size calculation which causes screen freezing
    - each implementation of `ScreenRecorder` now passes pre-scaled rects to `ScreenUpdateSubscriber`.